### PR TITLE
Error display is not formatted

### DIFF
--- a/lib/kernel.py
+++ b/lib/kernel.py
@@ -354,8 +354,8 @@ class KernelConnection(object):
         view: sublime.View = None,
     ) -> None:
         try:
-            lines = "\nError[{execution_count}]: {ename}, {evalue}."
-            "\nTraceback:\n{traceback}".format(
+            lines = """\nError[{execution_count}]: {ename}, {evalue}.
+            \nTraceback:\n{traceback}""".format(
                 execution_count=execution_count,
                 ename=ename,
                 evalue=evalue,


### PR DESCRIPTION
### Issue
Python errors in Helium on my ST3.2.2 started showing up as: 

```Error[{execution_count}]: {ename}, {evalue}.```

### Fix

Change " to """ in the relevant line of kernel.py