### PR TITLE
Helium Output: formatting and coloring

### DIFF
--- a/Helium.sublime-syntax
+++ b/Helium.sublime-syntax
@@ -1,0 +1,29 @@
+%YAML 1.2
+---
+name: Helium IPython
+scope: source.helium.output
+
+variables:
+  command_start: "In\\[\\d+\\]:"
+  error_start:   "Error\\[[^\\]]+\\]:"   # Not sure what should go inside the brackets of Error
+  streams:       "\\(stdout|display data|stderr\\):"
+
+contexts:
+
+
+  main:
+    - match: |-
+        \b({{command_start}})
+      comment: Cell contents formatted in python
+      name: cell.content
+      embed:  scope:source.python
+      escape: (?={{streams}}|{{command_start}}|{{error_start}}) # Outputs are formatted
+      captures:
+        1: markup.bold
+
+    - match: |-
+        ({{streams}})
+      name: streams
+      comment: Streams' names in bold
+      captures:
+        1: markup.italic 

--- a/lib/kernel.py
+++ b/lib/kernel.py
@@ -519,6 +519,7 @@ class KernelConnection(object):
             active_group = window.active_group()
             view = window.new_file()
             view.set_name(view_name)
+            view.settings().set("syntax", "Packages/Helium/Helium.sublime-syntax")
             num_group = window.num_groups()
             if num_group != 1:
                 if active_group + 1 < num_group:


### PR DESCRIPTION
# Goal

Format Helium Output's view in the following way:
  * Python code that is run is formatted according to Python.sublime-syntax
  * Cells delimiters are in bold, , e.g. **``In [1]:``**
  * Steam names are in italics, e.g. *``(stdout)``*

# Changes

  1. A language definition file: *Helium.sublime-syntax*.
  2. One line in *kernel.py* to set the syntax of the Helium Output view to this syntax file.